### PR TITLE
issues 77: Modification vocabulaire juridique

### DIFF
--- a/src/documents-templates/RequeteCecTribunal.vue
+++ b/src/documents-templates/RequeteCecTribunal.vue
@@ -226,7 +226,7 @@ const { renderValue, renderDate, genderSwitch, renderWithGender } = useDocumentT
     </blockquote>
     <p>
       De plus, il est inutile d’apporter des preuves pour tous les principaux faits mentionnés à
-      l’article 61-5 du Code Civil comme le stipule l’arrêt de la cour d’appel de Montpellier du 15
+      l’article 61-5 du Code Civil comme le précise l’arrêt de la cour d’appel de Montpellier du 15
       mars 2017 :
     </p>
     <blockquote>


### PR DESCRIPTION
retour par email

> le terme « stipule » n’est pas adapté pour qualifier un arrêt de cour d’appel. Le verbe « stipuler » s’emploie notamment pour une clause ou une disposition contractuelle. Pour un arrêt, il serait plus juste d’employer « précise », « indique » ou « a jugé ».

Fix #77