### PR TITLE
fix(template/cec): Replace "tribunal de grande instance" with "tribunal judiciaire"

### DIFF
--- a/src/documents-templates/RequeteCecTribunal.vue
+++ b/src/documents-templates/RequeteCecTribunal.vue
@@ -125,7 +125,7 @@ const { renderValue, renderDate, genderSwitch, renderWithGender } = useDocumentT
     </blockquote>
     <p>L’article 61-6 dudit code ajoute :</p>
     <blockquote>
-      <p>« La demande est présentée devant <strong>le tribunal de grande instance</strong>.</p>
+      <p>« La demande est présentée devant <strong>le tribunal judiciaire</strong>.</p>
       <p>
         Le demandeur fait état de son consentement libre et éclairé à la modification de la mention
         relative à son sexe dans les actes de l'état civil et produit tous éléments de preuve au


### PR DESCRIPTION
L'article 61-6 du code civil a été modifié par Ordonnance n°2019-964 du 18 septembre 2019 - art. 35.

https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039367731 https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039110945/2020-01-01